### PR TITLE
Pass custom origin information to rpm-ostree 

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,12 +61,12 @@ func Execute(cmd *cobra.Command, args []string) {
 		glog.Infof("Previous pivot: %s\n", previousPivot)
 	}
 
-	// Use skopeo to find the sha256, so we can refer to it reliably
+	// Use skopeo to canonicalize to $name@$digest, so we can refer to it reliably
 	output := utils.RunGetOut("skopeo", "inspect", fmt.Sprintf("docker://%s", container))
 
 	var imagedata types.ImageInspection
 	json.Unmarshal([]byte(output), &imagedata)
-	imgid := fmt.Sprintf("%s@%s", container, imagedata.Digest)
+	imgid := fmt.Sprintf("%s@%s", imagedata.Name, imagedata.Digest)
 
 	if previousPivot == imgid {
 		glog.Fatalf("Already pivoted to: %s\n", imgid)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -103,7 +103,7 @@ func Execute(cmd *cobra.Command, args []string) {
 
 	// The leading ':' here means "no remote".  See also
 	// https://github.com/projectatomic/rpm-ostree/pull/1396
-	utils.Run("rpm-ostree", "rebase", fmt.Sprintf(":%s", rev))
+	utils.Run("rpm-ostree", "rebase", fmt.Sprintf(":%s", rev), "--custom-origin-url", imgid, "--custom-origin-description", "Managed by pivot tool")
 
 	// Done!  Write our stamp file.  TODO: Teach rpm-ostree how to encode
 	// this data in the origin.


### PR DESCRIPTION
This is useful for admins but the URL is also needed by the MCD to
compare the state of the system.